### PR TITLE
Use ssh for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
 [submodule "impl/firedancer"]
 	path = impl/firedancer
-	url = https://github.com/firedancer-io/firedancer
+	url = git@github.com:firedancer-io/firedancer.git
 [submodule "impl/agave-v1.17"]
 	path = impl/agave-v1.17
-	url = https://github.com/firedancer-io/solfuzz-agave
+	url = git@github.com:firedancer-io/solfuzz-agave.git
 	branch = agave-v1.17
 [submodule "impl/agave-v2.0"]
 	path = impl/agave-v2.0
-	url = https://github.com/firedancer-io/solfuzz-agave
+	url = git@github.com:firedancer-io/solfuzz-agave.git
 	branch = agave-v2.0


### PR DESCRIPTION
As solfuzz-agave is now internal, using ssh to clone these submodules makes some of our scripts run smoother.