### PR TITLE
adding solfuzz as a submodule for easier triaging of crashes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,7 @@
 	path = impl/agave-v2.0
 	url = https://github.com/firedancer-io/solfuzz-agave
 	branch = agave-v2.0
+[submodule "impl/solfuzz"]
+	path = impl/solfuzz
+	url = https://github.com/firedancer-io/solfuzz
+	branch = main

--- a/impl/Makefile
+++ b/impl/Makefile
@@ -29,10 +29,22 @@ lib/libsolfuzz_firedancer.so:
 	ln -sf ../firedancer/build/native/clang/lib/libfd_exec_sol_compat.so lib/libsolfuzz_firedancer.so
 	ln -sf ../firedancer/build/native/clang/lib/libfd_ballet.a lib/libfd_ballet.a
 
+solfuzz/build/fuzz_sol_prog:
+	mkdir -p bin
+	[ ! -f solfuzz/shlr/protobuf ] && cd solfuzz && git submodule update --init --recursive && cd - || true
+	[ ! -f solfuzz/opt/bin/protoc ] && cd solfuzz && sys/deps.sh && cd - || true
+	cd solfuzz && cmake -B build -DCMAKE_CXX_COMPILER=clang++ . && cmake --build build && cd -
+
+bin/fuzz_sol_prog: solfuzz/build/fuzz_sol_prog
+	mkdir -p bin
+	ln -sf $(shell realpath $<) $@
+
 .PHONY: clean
 clean:
 	find lib -name '*.so' -delete || true
 	find lib -name '*.a' -delete || true
+	find bin -type l -delete || true
 	[ -d agave-v1.17 ] && $(MAKE) -C agave-v1.17 clean || true
 	[ -d agave-v2.0 ] && $(MAKE) -C agave-v2.0 clean || true
 	[ -d firedancer ] && rm -rf firedancer/opt && $(MAKE) -C firedancer distclean || true
+	[ -d solfuzz/build ] && rm -rf solfuzz/build || true


### PR DESCRIPTION
We're having trouble reproducing the many issues in https://github.com/firedancer-io/auditor-internal. The trouble reproducing mostly stems from differences in environment and working off of the same commit and building the same way.

The is the first PR in a sequence of PRs to make it easier for everyone to reproduce commands like
```
solfuzz/build/fuzz_sol_prog crash-103e6e3e88315a89943dc37abc933465c14b47c3
```