### PR TITLE
compare effects without encoding

### DIFF
--- a/src/test_suite/fuzz_interface.py
+++ b/src/test_suite/fuzz_interface.py
@@ -27,6 +27,22 @@ The following defines the interface:
 """
 
 
+def encode_hex_compact(buf):
+    res = ""
+    skipped = 0
+    for i in range(0, len(buf), 16):
+        row = buf[i : i + 16]
+        if row == bytes([0] * len(row)):
+            skipped += len(row)
+        else:
+            if skipped > 0:
+                res += f"...{skipped} zeros..."
+            res += "".join([f"{b:0>2x}" for b in buf[i : i + 16]])
+    if skipped > 0:
+        res += f"...{skipped} zeros..."
+    return bytes(res, "ascii")
+
+
 def generic_effects_prune(
     ctx: str | None, effects: dict[str, str | None]
 ) -> dict[str, str | None] | None:

--- a/src/test_suite/multiprocessing_utils.py
+++ b/src/test_suite/multiprocessing_utils.py
@@ -279,7 +279,6 @@ def build_test_results(results: dict[str, str | None]) -> tuple[int, dict | None
 
     ref_effects = globals.harness_ctx.effects_type()
     ref_effects.ParseFromString(ref_result)
-    globals.harness_ctx.effects_human_encode_fn(ref_effects)
 
     # Log execution results
     all_passed = True
@@ -292,14 +291,16 @@ def build_test_results(results: dict[str, str | None]) -> tuple[int, dict | None
             # Turn bytes into human readable fields
             effects = globals.harness_ctx.effects_type()
             effects.ParseFromString(result)
-            globals.harness_ctx.effects_human_encode_fn(effects)
 
             # Note: diff_effect_fn may modify effects in-place
             all_passed &= globals.harness_ctx.diff_effect_fn(ref_effects, effects)
+
+            globals.harness_ctx.effects_human_encode_fn(effects)
             outputs[target] = text_format.MessageToString(effects)
         else:
             all_passed = False
 
+    globals.harness_ctx.effects_human_encode_fn(ref_effects)
     outputs[globals.reference_shared_library] = text_format.MessageToString(ref_effects)
 
     # 1 = passed, -1 = failed

--- a/src/test_suite/syscall/codec_utils.py
+++ b/src/test_suite/syscall/codec_utils.py
@@ -1,5 +1,6 @@
 import base64
 import test_suite.vm_pb2 as vm_pb
+from test_suite.fuzz_interface import encode_hex_compact
 
 
 def encode_output(effects: vm_pb.SyscallEffects):
@@ -10,5 +11,6 @@ def encode_output(effects: vm_pb.SyscallEffects):
     Args:
         - effects (vm_pb.SyscallEffects): Syscall effects (will be modified).
     """
-    effects.heap = base64.b16encode(effects.heap)
-    effects.stack = b""
+    effects.heap = encode_hex_compact(effects.heap)
+    effects.stack = encode_hex_compact(effects.stack)
+    effects.rodata = encode_hex_compact(effects.rodata)


### PR DESCRIPTION
Also included new encoding for large binary e.g. stack & heap. This is an example of a failed test, where switching between 2 files makes it pretty evident where the difference is in the stack:

Result 1:
```
4d680fa93aa5104ad10e1e084b0b91693588ecf9_2256968:
cu_avail: 242729
heap: "...5885 zeros..."
stack: "...4080 zeros...000000000000000000000000c8c79359...231360 zeros...0000000000002dceffa69837808a4fd9...231360 zeros...91a4194a78eaead94495a22c8578b8cd...231360 zeros...0c2caf62a8ac1418d80fd1af6a4b93ec...231360 zeros...5a657bdbf597d1cada68940820fef3bf...231360 zeros...da7a2a51c15400000000000000000000...262048 zeros..."
rodata: "2dceffa69837808a4fd991a4194a78eaead94495a22c8578b8cd0c2caf62a8ac"
input_data_regions {
  content: "(9\351\315\264.#o\327\005\027]\014Gv\341\007.\367\223/\202j\275\270P\222g\2154\362\031\000\313|\260n\"\227\324B\264\356\227\354\275\205\321\021\211\315\267\250\304\\\237K\256Q\250\022V\2608"
}
```

Result 2:
```
4d680fa93aa5104ad10e1e084b0b91693588ecf9_2256968:
cu_avail: 242729
heap: "...5885 zeros..."
stack: "...4080 zeros...000000000000000000000000c8c79359...460736 zeros...0000000000002dceffa69837808a4fd9...460736 zeros...91a4194a78eaead94495a22c8578b8cd...460736 zeros...0c2caf62a8ac1418d80fd1af6a4b93ec...460736 zeros...5a657bdbf597d1cada68940820fef3bf...460736 zeros...da7a2a51c15400000000000000000000...524192 zeros..."
rodata: "2dceffa69837808a4fd991a4194a78eaead94495a22c8578b8cd0c2caf62a8ac"
input_data_regions {
  content: "(9\351\315\264.#o\327\005\027]\014Gv\341\007.\367\223/\202j\275\270P\222g\2154\362\031\000\313|\260n\"\227\324B\264\356\227\354\275\205\321\021\211\315\267\250\304\\\237K\256Q\250\022V\2608"
}
```