### PR TITLE
makefile: add recipe for agave v2.1.0

### DIFF
--- a/impl/Makefile
+++ b/impl/Makefile
@@ -1,6 +1,7 @@
 TARGETS:=
 TARGETS+=lib/libsolfuzz_agave_v1.17.so
 TARGETS+=lib/libsolfuzz_agave_v2.0.so
+TARGETS+=lib/libsolfuzz_agave_v2.1.0.so
 TARGETS+=lib/libsolfuzz_firedancer.so
 
 .PHONY: all $(TARGETS)
@@ -19,6 +20,13 @@ lib/libsolfuzz_agave_v2.0.so:
 	ln -sf ../agave-v2.0/target/x86_64-unknown-linux-gnu/release/libsolfuzz_agave.so lib/libsolfuzz_agave_sancov_v2.0.so
 	TERM=dumb cd agave-v2.0 && cargo build --lib
 	ln -sf ../agave-v2.0/target/debug/libsolfuzz_agave.so lib/libsolfuzz_agave_v2.0.so
+
+lib/libsolfuzz_agave_v2.1.0.so:
+	mkdir -p lib
+	TERM=dumb $(MAKE) -C agave-v2.1.0 build RUST_VERSION=""
+	ln -sf ../agave-v2.1.0/target/x86_64-unknown-linux-gnu/release/libsolfuzz_agave.so lib/libsolfuzz_agave_sancov_v2.1.0.so
+	TERM=dumb cd agave-v2.1.0 && cargo build --lib
+	ln -sf ../agave-v2.1.0/target/debug/libsolfuzz_agave.so lib/libsolfuzz_agave_v2.1.0.so
 
 lib/libsolfuzz_firedancer.so:
 	mkdir -p lib
@@ -46,5 +54,6 @@ clean:
 	find bin -type l -delete || true
 	[ -d agave-v1.17 ] && $(MAKE) -C agave-v1.17 clean || true
 	[ -d agave-v2.0 ] && $(MAKE) -C agave-v2.0 clean || true
+	[ -d agave-v2.1.0 ] && $(MAKE) -C agave-v2.1.0 clean || true
 	[ -d firedancer ] && rm -rf firedancer/opt && $(MAKE) -C firedancer distclean || true
 	[ -d solfuzz/build ] && rm -rf solfuzz/build || true


### PR DESCRIPTION
#### Problem
There are Makefile recipes to build Firedancer, Agave v1.17, and Agave v2.0 targets, but there isn't one for the Agave v2.1.0 target.

#### Summary of Changes
Add the new recipe!