### PR TITLE
add core bpf mode with new diff fn

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -231,6 +231,7 @@ $ solana-test-suite run-tests [OPTIONS]
 * `-c, --chunk-size INTEGER`: Number of test results per file  [default: 10000]
 * `-v, --verbose`: Verbose output: log failed test cases
 * `-c, --consensus-mode`: Only fail on consensus failures. One such effect is to normalize error codes when comparing results
+* `-cb, --core-bpf-mode`: Deliberately skip known mismatches between BPF programs and builtins, only failing on genuine mimatches. For example, builtin programs may throw errors on readonly account state violations sooner than BPF programs, compute unit usage will be different, etc. This feature is primarily used to test a BPF program against a builtin.
 * `-f, --failures-only`: Only log failed test cases
 * `-sf, --save-failures`: Saves failed test cases to results directory
 * `-ss, --save-successes`: Saves successful test cases to results directory

--- a/commands.md
+++ b/commands.md
@@ -230,8 +230,8 @@ $ solana-test-suite run-tests [OPTIONS]
 * `-r, --randomize-output-buffer`: Randomizes bytes in output buffer before shared library execution
 * `-c, --chunk-size INTEGER`: Number of test results per file  [default: 10000]
 * `-v, --verbose`: Verbose output: log failed test cases
-* `-c, --consensus-mode`: Only fail on consensus failures. One such effect is to normalize error codes when comparing results
-* `-cb, --core-bpf-mode`: Deliberately skip known mismatches between BPF programs and builtins, only failing on genuine mimatches. For example, builtin programs may throw errors on readonly account state violations sooner than BPF programs, compute unit usage will be different, etc. This feature is primarily used to test a BPF program against a builtin.
+* `-c, --consensus-mode`: Only fail on consensus failures. One such effect is to normalize error codes when comparing results. Note: Cannot be used with --core-bpf-mode.
+* `-cb, --core-bpf-mode`: Deliberately skip known mismatches between BPF programs and builtins, only failing on genuine mimatches. For example, builtin programs may throw errors on readonly account state violations sooner than BPF programs, compute unit usage will be different, etc. This feature is primarily used to test a BPF program against a builtin. Note: Cannot be used with --consensus-mode.
 * `-f, --failures-only`: Only log failed test cases
 * `-sf, --save-failures`: Saves failed test cases to results directory
 * `-ss, --save-successes`: Saves successful test cases to results directory

--- a/src/test_suite/fuzz_context.py
+++ b/src/test_suite/fuzz_context.py
@@ -25,6 +25,7 @@ InstrHarness = HarnessCtx(
     context_human_decode_fn=instr_codec.decode_input,
     effects_human_encode_fn=instr_codec.encode_output,
     consensus_diff_effect_fn=instr_diff.consensus_instr_diff_effects,
+    core_bpf_diff_effect_fn=instr_diff.core_bpf_instr_diff_effects,
 )
 
 SyscallHarness = HarnessCtx(

--- a/src/test_suite/fuzz_interface.py
+++ b/src/test_suite/fuzz_interface.py
@@ -88,6 +88,9 @@ class HarnessCtx:
     consensus_diff_effect_fn: Callable[[EffectsType, EffectsType], bool] = (
         generic_effects_diff
     )
+    core_bpf_diff_effect_fn: Callable[[EffectsType, EffectsType], bool] = (
+        generic_effects_diff
+    )
     prune_effects_fn: Callable[
         [ContextType | None, dict[str, str | None]], dict[str, str | None] | None
     ] = generic_effects_prune

--- a/src/test_suite/instr/diff_utils.py
+++ b/src/test_suite/instr/diff_utils.py
@@ -1,4 +1,22 @@
+from enum import Enum
 import test_suite.invoke_pb2 as invoke_pb
+
+
+class DiffMode(Enum):
+    STANDARD = 0
+    CONSENSUS = 1
+    CORE_BPF = 2
+
+    def apply_diff(self, a: invoke_pb.InstrEffects, b: invoke_pb.InstrEffects):
+        """Applies the specified diff effects.
+        - STANDARD: No diff effects.
+        - CONSENSUS: Consensus-only diff effects.
+        - CORE_BPF: Core BPF diff effects for testing a BPF program against a builtin.
+        """
+        if self == DiffMode.CONSENSUS:
+            return consensus_instr_diff_effects(a, b)
+        if self == DiffMode.CORE_BPF:
+            return core_bpf_instr_diff_effects(a, b)
 
 
 def consensus_instr_diff_effects(a: invoke_pb.InstrEffects, b: invoke_pb.InstrEffects):
@@ -6,6 +24,32 @@ def consensus_instr_diff_effects(a: invoke_pb.InstrEffects, b: invoke_pb.InstrEf
     a_san.CopyFrom(a)
     b_san = invoke_pb.InstrEffects()
     b_san.CopyFrom(b)
+
+    # Normalize error codes and cus
+    a_san.result = 0
+    a_san.custom_err = 0
+    a_san.cu_avail = 0
+
+    b_san.result = 0
+    b_san.custom_err = 0
+    b_san.cu_avail = 0
+
+    return a_san == b_san
+
+
+def core_bpf_instr_diff_effects(a: invoke_pb.InstrEffects, b: invoke_pb.InstrEffects):
+    a_san = invoke_pb.InstrEffects()
+    a_san.CopyFrom(a)
+    b_san = invoke_pb.InstrEffects()
+    b_san.CopyFrom(b)
+
+    # If the result is an error (not 0), don't return modified accounts.
+    if a_san.result != 0:
+        while len(a_san.modified_accounts) > 0:
+            a_san.modified_accounts.pop()
+    if b_san.result != 0:
+        while len(b_san.modified_accounts) > 0:
+            b_san.modified_accounts.pop()
 
     # Normalize error codes and cus
     a_san.result = 0

--- a/src/test_suite/instr/diff_utils.py
+++ b/src/test_suite/instr/diff_utils.py
@@ -1,22 +1,4 @@
-from enum import Enum
 import test_suite.invoke_pb2 as invoke_pb
-
-
-class DiffMode(Enum):
-    STANDARD = 0
-    CONSENSUS = 1
-    CORE_BPF = 2
-
-    def apply_diff(self, a: invoke_pb.InstrEffects, b: invoke_pb.InstrEffects):
-        """Applies the specified diff effects.
-        - STANDARD: No diff effects.
-        - CONSENSUS: Consensus-only diff effects.
-        - CORE_BPF: Core BPF diff effects for testing a BPF program against a builtin.
-        """
-        if self == DiffMode.CONSENSUS:
-            return consensus_instr_diff_effects(a, b)
-        if self == DiffMode.CORE_BPF:
-            return core_bpf_instr_diff_effects(a, b)
 
 
 def consensus_instr_diff_effects(a: invoke_pb.InstrEffects, b: invoke_pb.InstrEffects):

--- a/src/test_suite/multiprocessing_utils.py
+++ b/src/test_suite/multiprocessing_utils.py
@@ -314,11 +314,8 @@ def build_test_results(
             effects = harness_ctx.effects_type()
             effects.ParseFromString(result)
 
-            if globals.consensus_mode:
-                harness_ctx.diff_effect_fn = harness_ctx.consensus_diff_effect_fn
-
-            # Note: diff_effect_fn may modify effects in-place
-            all_passed &= harness_ctx.diff_effect_fn(ref_effects, effects)
+            # Note: apply_diff may modify effects in-place
+            all_passed &= globals.diff_mode.apply_diff(ref_effects, effects)
 
             harness_ctx.effects_human_encode_fn(effects)
             outputs[target] = text_format.MessageToString(effects)

--- a/src/test_suite/multiprocessing_utils.py
+++ b/src/test_suite/multiprocessing_utils.py
@@ -314,8 +314,13 @@ def build_test_results(
             effects = harness_ctx.effects_type()
             effects.ParseFromString(result)
 
-            # Note: apply_diff may modify effects in-place
-            all_passed &= globals.diff_mode.apply_diff(ref_effects, effects)
+            if globals.consensus_mode:
+                harness_ctx.diff_effect_fn = harness_ctx.consensus_diff_effect_fn
+            if globals.core_bpf_mode:
+                harness_ctx.diff_effect_fn = harness_ctx.core_bpf_diff_effect_fn
+
+            # Note: diff_effect_fn may modify effects in-place
+            all_passed &= harness_ctx.diff_effect_fn(ref_effects, effects)
 
             harness_ctx.effects_human_encode_fn(effects)
             outputs[target] = text_format.MessageToString(effects)

--- a/src/test_suite/test_suite.py
+++ b/src/test_suite/test_suite.py
@@ -354,7 +354,8 @@ def run_tests(
         False,
         "--consensus-mode",
         "-c",
-        help="Only fail on consensus failures. One such effect is to normalize error codes when comparing results",
+        help="Only fail on consensus failures. One such effect is to normalize error codes when comparing results. \
+Note: Cannot be used with --core-bpf-mode.",
     ),
     core_bpf_mode: bool = typer.Option(
         False,
@@ -362,7 +363,8 @@ def run_tests(
         "-cb",
         help="Deliberately skip known mismatches between BPF programs and builtins, only failing on genuine mimatches. \
 For example, builtin programs may throw errors on readonly account state violations sooner than BPF programs, \
-compute unit usage will be different, etc. This feature is primarily used to test a BPF program against a builtin.",
+compute unit usage will be different, etc. This feature is primarily used to test a BPF program against a builtin. \
+Note: Cannot be used with --consensus-mode.",
     ),
     failures_only: bool = typer.Option(
         False,

--- a/src/test_suite/test_suite.py
+++ b/src/test_suite/test_suite.py
@@ -17,7 +17,6 @@ from test_suite.fixture_utils import (
     extract_context_from_fixture,
     write_fixture_to_disk,
 )
-from test_suite.instr.diff_utils import DiffMode
 from test_suite.log_utils import log_results
 from test_suite.multiprocessing_utils import (
     decode_single_test_case,
@@ -406,12 +405,10 @@ Note: Cannot be used with --consensus-mode.",
             err=True,
         )
         raise typer.Exit(code=1)
-    if consensus_mode:
-        globals.diff_mode = DiffMode.CONSENSUS
-    elif core_bpf_mode:
-        globals.diff_mode = DiffMode.CORE_BPF
-    else:
-        globals.diff_mode = DIffMode.STANDARD
+    # Set diff mode to consensus if specified
+    globals.consensus_mode = consensus_mode
+    # Set diff mode to core_bpf if specified
+    globals.core_bpf_mode = core_bpf_mode
 
     # Create the output directory, if necessary
     if globals.output_dir.exists():


### PR DESCRIPTION
This PR adds a new, additional CLI flag `--core-bpf-mode` which behaves similar to `--consensus-mode` in that it just applies a special diff function to the source and target effects post-execution.

The two flags cannot be used together, since only one diff function should be applied.

We can further add custom dif-processing to the new diff function offered by `core-bpf-mode`, without muddying up the rest of the harness or trying to maintain it on a separate branch.