### PR TITLE
fix: elf_proto_converter import

### DIFF
--- a/src/test_suite/elf_loader/elf_proto_converter.py
+++ b/src/test_suite/elf_loader/elf_proto_converter.py
@@ -1,5 +1,5 @@
 from enum import Enum
-import test_suite.invoke_pb2 as elf_pb
+import test_suite.elf_pb2 as elf_pb
 from argparse import ArgumentParser
 from pathlib import Path
 from typing import Callable


### PR DESCRIPTION
```
$ python3 src/test_suite/elf_loader/elf_proto_converter.py ctx2bin ...
Traceback (most recent call last):
  File "/root/solana-conformance/src/test_suite/elf_loader/elf_proto_converter.py", line 92, in <module>
    def ctx_fill_sz(ctx: elf_pb.ELFLoaderCtx):
                         ^^^^^^^^^^^^^^^^^^^
AttributeError: module 'test_suite.invoke_pb2' has no attribute 'ELFLoaderCtx'
```