### PR TITLE
diff mode: ignore-compute-units

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -272,8 +272,9 @@ $ solana-test-suite run-tests [OPTIONS]
 * `-r, --randomize-output-buffer`: Randomizes bytes in output buffer before shared library execution
 * `-c, --chunk-size INTEGER`: Number of test results per file  [default: 10000]
 * `-v, --verbose`: Verbose output: log failed test cases
-* `-c, --consensus-mode`: Only fail on consensus failures. One such effect is to normalize error codes when comparing results. Note: Cannot be used with --core-bpf-mode.
-* `-cb, --core-bpf-mode`: Deliberately skip known mismatches between BPF programs and builtins, only failing on genuine mimatches. For example, builtin programs may throw errors on readonly account state violations sooner than BPF programs, compute unit usage will be different, etc. This feature is primarily used to test a BPF program against a builtin. Note: Cannot be used with --consensus-mode.
+* `-c, --consensus-mode`: Only fail on consensus failures. One such effect is to normalize error codes when comparing results. Note: Cannot be used with --core-bpf-mode or --ignore-compute-units-mode.
+* `-cb, --core-bpf-mode`: Deliberately skip known mismatches between BPF programs and builtins, only failing on genuine mimatches. For example, builtin programs may throw errors on readonly account state violations sooner than BPF programs, compute unit usage will be different, etc. This feature is primarily used to test a BPF program against a builtin. Note: Cannot be used with --consensus-mode or --ignore-compute-units-mode.
+* `--ignore-compute-units`: Skip mismatches on only compute units. Good for testing two versions of a BPF program, where one is expected to use different amounts of compute units than the other. Note: Cannot be used with --consensus-mode or --core-bpf-mode.
 * `-f, --failures-only`: Only log failed test cases
 * `-sf, --save-failures`: Saves failed test cases to results directory
 * `-ss, --save-successes`: Saves successful test cases to results directory

--- a/src/test_suite/fuzz_context.py
+++ b/src/test_suite/fuzz_context.py
@@ -41,6 +41,7 @@ InstrHarness = HarnessCtx(
     effects_human_encode_fn=instr_codec.encode_output,
     consensus_diff_effect_fn=instr_diff.consensus_instr_diff_effects,
     core_bpf_diff_effect_fn=instr_diff.core_bpf_instr_diff_effects,
+    ignore_compute_units_diff_effect_fn=instr_diff.ignore_compute_units_instr_diff_effects,
     regenerate_transformation_fn=instr_transform.transform_fixture,
 )
 

--- a/src/test_suite/fuzz_interface.py
+++ b/src/test_suite/fuzz_interface.py
@@ -102,6 +102,9 @@ class HarnessCtx:
     core_bpf_diff_effect_fn: Callable[[EffectsType, EffectsType], bool] = (
         generic_effects_diff
     )
+    ignore_compute_units_diff_effect_fn: Callable[[EffectsType, EffectsType], bool] = (
+        generic_effects_diff
+    )
     prune_effects_fn: Callable[
         [ContextType | None, dict[str, str | None]], dict[str, str | None] | None
     ] = generic_effects_prune

--- a/src/test_suite/globals.py
+++ b/src/test_suite/globals.py
@@ -40,6 +40,9 @@ consensus_mode: bool = False
 # Whether to run in core bpf mode
 core_bpf_mode: bool = False
 
+# Whether to run in "ignore compute units" mode
+ignore_compute_units_mode: bool = False
+
 # For regenerating fixtures
 features_to_add: set[int] = set()
 features_to_remove: set[int] = set()

--- a/src/test_suite/instr/diff_utils.py
+++ b/src/test_suite/instr/diff_utils.py
@@ -43,3 +43,18 @@ def core_bpf_instr_diff_effects(a: invoke_pb.InstrEffects, b: invoke_pb.InstrEff
     b_san.cu_avail = 0
 
     return a_san == b_san
+
+
+def ignore_compute_units_instr_diff_effects(
+    a: invoke_pb.InstrEffects, b: invoke_pb.InstrEffects
+):
+    a_san = invoke_pb.InstrEffects()
+    a_san.CopyFrom(a)
+    b_san = invoke_pb.InstrEffects()
+    b_san.CopyFrom(b)
+
+    a_san.cu_avail = 0
+
+    b_san.cu_avail = 0
+
+    return a_san == b_san

--- a/src/test_suite/multiprocessing_utils.py
+++ b/src/test_suite/multiprocessing_utils.py
@@ -338,6 +338,10 @@ def build_test_results(
                 harness_ctx.diff_effect_fn = harness_ctx.consensus_diff_effect_fn
             if globals.core_bpf_mode:
                 harness_ctx.diff_effect_fn = harness_ctx.core_bpf_diff_effect_fn
+            if globals.ignore_compute_units_mode:
+                harness_ctx.diff_effect_fn = (
+                    harness_ctx.ignore_compute_units_diff_effect_fn
+                )
 
             # Note: diff_effect_fn may modify effects in-place
             all_passed &= harness_ctx.diff_effect_fn(ref_effects, effects)


### PR DESCRIPTION
Adds a new diff mode for just ignoring compute units. Useful for conformance-testing between two BPF programs which are known to use different amounts of compute units.