### PR TITLE
fix undefined symbols and correct how ASAN lib is chosen

### DIFF
--- a/src/test_suite/test_suite.py
+++ b/src/test_suite/test_suite.py
@@ -274,9 +274,12 @@ def create_fixtures(
     # Initialize shared library
     for target in shared_libraries:
         # Load in and initialize shared libraries
-        lib = ctypes.CDLL(target)
-        lib.sol_compat_init(log_level)
-        globals.target_libraries[target] = lib
+        try:
+            lib = ctypes.CDLL(target)
+            lib.sol_compat_init(log_level)
+            globals.target_libraries[target] = lib
+        except:
+            set_ld_preload_asan()
 
     test_cases = [input] if input.is_file() else list(input.iterdir())
     num_test_cases = len(test_cases)
@@ -442,9 +445,12 @@ expected to use different amounts of compute units than the other. Note: Cannot 
     # Initialize shared libraries
     for target in shared_libraries:
         # Load in and initialize shared libraries
-        lib = ctypes.CDLL(target)
-        lib.sol_compat_init(log_level)
-        globals.target_libraries[target] = lib
+        try:
+            lib = ctypes.CDLL(target)
+            lib.sol_compat_init(log_level)
+            globals.target_libraries[target] = lib
+        except:
+            set_ld_preload_asan()
 
         # Make log output directories for each shared library
         log_dir = globals.output_dir / target.stem
@@ -882,10 +888,13 @@ def regenerate_fixtures(
     if globals.output_dir.exists():
         shutil.rmtree(globals.output_dir)
     globals.output_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        lib: ctypes.CDLL = ctypes.CDLL(shared_library)
+        lib.sol_compat_init(log_level)
+        globals.target_libraries[shared_library] = lib
+    except:
+        set_ld_preload_asan()
 
-    lib: ctypes.CDLL = ctypes.CDLL(shared_library)
-    lib.sol_compat_init(log_level)
-    globals.target_libraries[shared_library] = lib
     initialize_process_output_buffers()
 
     test_cases = list(input.iterdir()) if input.is_dir() else [input]

--- a/src/test_suite/util.py
+++ b/src/test_suite/util.py
@@ -5,10 +5,14 @@ import sys
 
 def set_ld_preload_asan():
     # Run ldconfig -p and capture output
-    ldconfig_output = subprocess.check_output(["ldconfig", "-p"], text=True)
+    ldconfig_output = subprocess.check_output(["sudo", "ldconfig", "-p"], text=True)
 
-    # Filter lines containing "asan"
-    asan_libs = [line for line in ldconfig_output.split("\n") if "asan" in line]
+    # Filter lines containing "asan", excluding HWASAN
+    asan_libs = [
+        line
+        for line in ldconfig_output.split("\n")
+        if "asan" in line and "hwasan" not in line
+    ]
 
     # Extract the first library path if available
     if asan_libs:


### PR DESCRIPTION
Prior to this patch, I get this error for `exec-fixtures` and `create-fixtures`:
```
undefined symbol: __sanitizer_cov_8bit_counters_init
```

Second, the way the ASAN chosen required `sudo` on my system and was incorrectly picking up `lib/x86_64-linux-gnu/libhwasan.so.0`