### PR TITLE
Use idiomatic Python dependencies for downloading, unzipping instead of brittle shell invocations

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -54,6 +54,7 @@ $ solana-test-suite create-env [OPTIONS]
 * `-fd, --firedancer-repo PATH`: Path to firedancer repository
 * `-tv, --test-vectors-repo PATH`: Path to test-vectors repository
 * `--use-ng`: Use fuzz NG CLI (fuzz list/download repro) instead of API scraping
+* `-d, --debug-mode`: Enables debug mode, which disables multiprocessing
 * `--help`: Show this message and exit.
 
 ## `solana-test-suite create-fixtures`
@@ -109,6 +110,7 @@ $ solana-test-suite debug-mismatches [OPTIONS]
 * `-p, --num-processes INTEGER`: Number of processes to use  [default: 4]
 * `-l, --section-limit INTEGER`: Limit number of fixture per section  [default: 0]
 * `--use-ng`: Use fuzz NG CLI (fuzz list/download repro) instead of API scraping
+* `-d, --debug-mode`: Enables debug mode, which disables multiprocessing
 * `--help`: Show this message and exit.
 
 ## `solana-test-suite decode-protobufs`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
   "tqdm~=4.66.0",
   "protoletariat~=3.2.0",
   "bs4~=0.0.2",
-  "click<8.2.0"
+  "click<8.2.0",
+  "requests~=2.32.0",
 ]
 
 [project.scripts]

--- a/src/test_suite/multiprocessing_utils.py
+++ b/src/test_suite/multiprocessing_utils.py
@@ -15,6 +15,9 @@ from google.protobuf import text_format, message
 from google.protobuf.internal.decoder import _DecodeVarint
 import os
 import re
+import requests
+import time
+import zipfile
 
 
 def process_target(
@@ -438,55 +441,66 @@ def execute_fixture(test_file: Path) -> tuple[str, int, dict | None]:
     )
 
 
+def download_with_retries(url, dest_path, retries=3, backoff=2):
+    for attempt in range(1, retries + 1):
+        try:
+            with requests.get(url, stream=True, timeout=30) as r:
+                r.raise_for_status()
+                with open(dest_path, "wb") as f:
+                    for chunk in r.iter_content(chunk_size=8192):
+                        if chunk:
+                            f.write(chunk)
+            return  # Success — exit the function
+        except requests.RequestException as e:
+            if attempt < retries:
+                sleep_time = backoff ** (attempt - 1)
+                time.sleep(sleep_time)
+            else:
+                raise RuntimeError(
+                    f"Failed to download {url} after {retries} attempts"
+                ) from e
+
+
 def download_and_process(source):
-    if isinstance(source, (tuple, list)) and len(source) == 2:
-        section_name, crash_hash = source
-        out_dir = globals.inputs_dir / f"{section_name}_{crash_hash}"
-        out_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        if isinstance(source, (tuple, list)) and len(source) == 2:
+            section_name, crash_hash = source
+            out_dir = globals.inputs_dir / f"{section_name}_{crash_hash}"
+            out_dir.mkdir(parents=True, exist_ok=True)
 
-        fuzz_bin = os.getenv("FUZZ_BIN", "fuzz")
-        subprocess.run(
-            [
-                fuzz_bin,
-                "download",
-                "repro",
-                "--lineage",
-                section_name,
-                "--out-dir",
-                str(out_dir),
-                crash_hash,
-            ],
-            text=True,
-            check=True,
-            stderr=None,
-        )
+            fuzz_bin = os.getenv("FUZZ_BIN", "fuzz")
+            subprocess.run(
+                [
+                    fuzz_bin,
+                    "download",
+                    "repro",
+                    "--lineage",
+                    section_name,
+                    "--out-dir",
+                    str(out_dir),
+                    crash_hash,
+                ],
+                text=True,
+                check=True,
+                stderr=None,
+            )
 
-        for fix in out_dir.rglob("*.fix"):
-            shutil.copy2(fix, globals.inputs_dir)
-        return f"Processed {section_name}/{crash_hash} successfully"
+            for fix in out_dir.rglob("*.fix"):
+                shutil.copy2(fix, globals.inputs_dir)
+            return f"Processed {section_name}/{crash_hash} successfully"
 
-    else:
-        zip_name = source.split("/")[-1]
+        else:
+            zip_name = Path(source).name
+            dest_file = globals.output_dir / zip_name
+            download_with_retries(source, dest_file)
 
-        # Step 1: Download the file
-        result = subprocess.run(
-            ["wget", "-q", source, "-O", f"{globals.output_dir}/{zip_name}"],
-            capture_output=True,
-            text=True,
-        )
+            with zipfile.ZipFile(f"{globals.output_dir}/{zip_name}") as z:
+                z.extractall(globals.output_dir)
 
-        result = subprocess.run(
-            ["unzip", f"{globals.output_dir}/{zip_name}", "-d", globals.output_dir],
-            capture_output=True,
-            text=True,
-        )
+            for fix in (globals.output_dir / "repro_custom").glob("*.fix"):
+                shutil.copy2(fix, globals.inputs_dir)
+            return f"Processed {zip_name} successfully"
 
-        result = subprocess.run(
-            f"mv {globals.output_dir}/repro_custom/*.fix {globals.inputs_dir}",
-            shell=True,
-            capture_output=True,
-            text=True,
-        )
-        return f"Processed {zip_name} successfully"
-
-    return f"Unsupported source: {source}"
+        return f"Unsupported source: {source}"
+    except Exception as e:
+        return f"Error processing {source}: {str(e)}"

--- a/src/test_suite/test_suite.py
+++ b/src/test_suite/test_suite.py
@@ -661,6 +661,12 @@ def debug_mismatches(
         "--use-ng",
         help="Use fuzz NG CLI (fuzz list/download repro) instead of API scraping",
     ),
+    debug_mode: bool = typer.Option(
+        False,
+        "--debug-mode",
+        "-d",
+        help="Enables debug mode, which disables multiprocessing",
+    ),
 ):
     initialize_process_output_buffers(randomize_output_buffer=randomize_output_buffer)
 
@@ -781,7 +787,7 @@ def debug_mismatches(
     num_test_cases = len(custom_data_urls)
     print("Downloading tests...")
     results = []
-    if num_processes > 1:
+    if num_processes > 1 and not debug_mode:
         with Pool(
             processes=num_processes,
             initializer=initialize_process_output_buffers,
@@ -1317,6 +1323,12 @@ def create_env(
         "--use-ng",
         help="Use fuzz NG CLI (fuzz list/download repro) instead of API scraping",
     ),
+    debug_mode: bool = typer.Option(
+        False,
+        "--debug-mode",
+        "-d",
+        help="Enables debug mode, which disables multiprocessing",
+    ),
 ):
     lists = [
         f"{file.parent.name}/{file.name}"
@@ -1366,6 +1378,7 @@ def create_env(
         num_processes=num_processes,
         section_limit=section_limit,
         use_ng=use_ng,
+        debug_mode=debug_mode,
     )
 
     if passed:


### PR DESCRIPTION
Repro:
```
(test_suite_env) [kbhargava@tsnj2-ossdev-firedancer38 solana-conformance]$ solana-test-suite debug-mismatches -n sol_elf_loader_diff -o sol_elf_loader_diff
Getting links from section sol_elf_loader_diff...
Downloading tests...
  0%|                                                                                                                                                                                                                                                                                                                                                 | 0/4 [00:00<?, ?it/s]
```

Bad filename from Fuzzcorp with special characters needed shell escaping, causing the `unzip` to hang: `Downloading test from https://fuzzcorp-custom-output-9fb067e.s3.us-east-2.amazonaws.com/org_rvfruw8l/prj_rvfruw8lACo/atc_rvfruw8lACogLEQRk-54-w.zip`

Improved error handling and added missing debug flags while I was at it.