### PR TITLE
pyproject: bump protobuf version to 6.33

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
   "bs4~=0.0.2",
   "click<8.2.0",
   "requests~=2.32.0",
-  "protobuf==6.32.1",
+  "protobuf~=6.33.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
buf generates python code that requires protobuf 6.33.0, but we require protobuf 6.32.1.