### PR TITLE
Add BundleID fallback

### DIFF
--- a/src/test_suite/fuzzcorp_api_client.py
+++ b/src/test_suite/fuzzcorp_api_client.py
@@ -60,7 +60,7 @@ class ReproIndexResponse:
             lineages[lineage_name] = [LineageRepro.from_dict(r) for r in repros]
 
         return cls(
-            bundle_id=data["BundleID"],
+            bundle_id=data.get("BundleID", "00000000-0000-0000-0000-000000000000"),
             lineages=lineages,
         )
 


### PR DESCRIPTION
Addresses the following stack trace:
```
(test_suite_env) ➜  solana-conformance git:(main) solana-conformance debug-mismatches -n sol_txn_diff -o scratch/txn -d
Fetching repro index from https://firedancer.staging.fuzzcorp.asymmetric.re/...
[ERROR] Request failed: 'BundleID'
Traceback (most recent call last):
  File "/home/rsivakumaran/repos/solana-conformance/src/test_suite/fuzzcorp_utils.py", line 76, in fuzzcorp_api_call
    result = api_func(client)
             ^^^^^^^^^^^^^^^^
  File "/home/rsivakumaran/repos/solana-conformance/src/test_suite/test_suite.py", line 1382, in fetch_repros
    return client.list_repros()
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/rsivakumaran/repos/solana-conformance/src/test_suite/fuzzcorp_api_client.py", line 219, in list_repros
    return ReproIndexResponse.from_dict(response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rsivakumaran/repos/solana-conformance/src/test_suite/fuzzcorp_api_client.py", line 63, in from_dict
    bundle_id=data["BundleID"],
              ~~~~^^^^^^^^^^^^
KeyError: 'BundleID'
```