### PR TITLE
Switch to multiprocessing for FFI calls

### DIFF
--- a/src/test_suite/test_suite.py
+++ b/src/test_suite/test_suite.py
@@ -337,6 +337,7 @@ def create_fixtures(
         debug_mode=debug_mode,
         initializer=initialize_process_output_buffers,
         desc="Creating fixtures",
+        use_processes=True,
     )
 
     # Clean up
@@ -543,6 +544,7 @@ expected to use different amounts of compute units than the other. Note: Cannot 
             initializer=initialize_process_output_buffers,
             initargs=(randomize_output_buffer,),
             desc="Running tests",
+            use_processes=True,
         )
 
     print("Logging results...")
@@ -2064,6 +2066,7 @@ def exec_fixtures(
         initializer=initialize_process_output_buffers,
         initargs=(randomize_output_buffer,),
         desc="Running tests",
+        use_processes=True,
     )
 
     print("Logging results...")


### PR DESCRIPTION
In some cases, we had seen stack overflows caused by the smaller per-thread stack size, exacerbated by oversized FFI frames:

```
CRIT    11-03 23:33:20.963739 2816635 f0   1    src/flamenco/runtime/sysvar/fd_sysvar.c(53): fd_alloca_check( 1UL, FD_BASE58_ENCODED_32_SZ ) stack overflow
ERR     11-03 23:33:20.963778 2816635 f0   1    src/util/log/fd_log.c(1036): Received signal SIGABRT-Aborted
/home/rsivakumaran/repos/firedancer/build/debug/lib/libfd_exec_sol_compat.so(+0x934c7a) [0x7fffee734c7a]
/lib64/libc.so.6(+0x3ebf0) [0x7ffff743ebf0]
/lib64/libc.so.6(+0x8bedc) [0x7ffff748bedc]
/lib64/libc.so.6(raise+0x16) [0x7ffff743eb46]
/lib64/libc.so.6(abort+0xd3) [0x7ffff7428833]
/home/rsivakumaran/repos/firedancer/build/debug/lib/libfd_exec_sol_compat.so(+0x934965) [0x7fffee734965]
/home/rsivakumaran/repos/firedancer/build/debug/lib/libfd_exec_sol_compat.so(+0x309d07) [0x7fffee109d07]
/home/rsivakumaran/repos/firedancer/build/debug/lib/libfd_exec_sol_compat.so(+0x3565d6) [0x7fffee1565d6]
/home/rsivakumaran/repos/firedancer/build/debug/lib/libfd_exec_sol_compat.so(+0x356887) [0x7fffee156887]
/home/rsivakumaran/repos/firedancer/build/debug/lib/libfd_exec_sol_compat.so(+0x659a0) [0x7fffede659a0]
/home/rsivakumaran/repos/firedancer/build/debug/lib/libfd_exec_sol_compat.so(+0x678e4) [0x7fffede678e4]
/home/rsivakumaran/repos/firedancer/build/debug/lib/libfd_exec_sol_compat.so(+0x246a1) [0x7fffede246a1]
/home/rsivakumaran/repos/firedancer/build/debug/lib/libfd_exec_sol_compat.so(sol_compat_txn_execute_v1+0xec) [0x7fffede255cc]
/lib64/libffi.so.8(+0x78d6) [0x7ffff61df8d6]
/lib64/libffi.so.8(+0x4556) [0x7ffff61dc556]
/usr/lib64/python3.11/lib-dynload/_ctypes.cpython-311-x86_64-linux-gnu.so(+0xa520) [0x7ffff6d24520]
/usr/lib64/python3.11/lib-dynload/_ctypes.cpython-311-x86_64-linux-gnu.so(+0x13ed3) [0x7ffff6d2ded3]
/lib64/libpython3.11.so.1.0(_PyObject_MakeTpCall+0x29c) [0x7ffff79e53ec]
/lib64/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x818) [0x7ffff79f1048]
/lib64/libpython3.11.so.1.0(_PyFunction_Vectorcall+0x186) [0x7ffff7a1c786]
/lib64/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x5124) [0x7ffff79f5954]
/lib64/libpython3.11.so.1.0(_PyFunction_Vectorcall+0x186) [0x7ffff7a1c786]
/lib64/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x5124) [0x7ffff79f5954]
/lib64/libpython3.11.so.1.0(+0x23d9fd) [0x7ffff7a3d9fd]
/lib64/libpython3.11.so.1.0(+0x23d4a0) [0x7ffff7a3d4a0]
/lib64/libpython3.11.so.1.0(+0x31b8bc) [0x7ffff7b1b8bc]
/lib64/libpython3.11.so.1.0(+0x2e7e38) [0x7ffff7ae7e38]
/lib64/libc.so.6(+0x8a19a) [0x7ffff748a19a]
/lib64/libc.so.6(+0x10f210) [0x7ffff750f210]
```